### PR TITLE
[Step1] 사용자 인가 구현

### DIFF
--- a/src/main/java/nextstep/app/application/MemberUserDetailsService.java
+++ b/src/main/java/nextstep/app/application/MemberUserDetailsService.java
@@ -19,6 +19,6 @@ public class MemberUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws AuthenticationException {
         Member member = memberRepository.findByEmail(username).orElseThrow(AuthenticationException::new);
-        return new BaseUser(member.getEmail(), member.getPassword());
+        return new BaseUser(member.getEmail(), member.getPassword(), member.getRoles());
     }
 }

--- a/src/main/java/nextstep/app/config/AuthConfig.java
+++ b/src/main/java/nextstep/app/config/AuthConfig.java
@@ -67,7 +67,7 @@ public class AuthConfig implements WebMvcConfigurer {
 
         List<Filter> filters = new ArrayList<>();
         filters.add(new BasicAuthenticationFilter(authenticationManager()));
-        filters.add(new AuthorizationFilter(ROLE_NAME));
+        filters.add(new AuthorizationFilter(ROLE_NAME, securityContextRepository()));
 
         return new DefaultSecurityFilterChain(MEMBERS_REQUEST_MATCHER, filters);
     }

--- a/src/main/java/nextstep/app/config/AuthConfig.java
+++ b/src/main/java/nextstep/app/config/AuthConfig.java
@@ -1,10 +1,8 @@
 package nextstep.app.config;
 
 import nextstep.security.access.matcher.AnyRequestMatcher;
-import nextstep.security.authentication.AuthenticationManager;
-import nextstep.security.authentication.BasicAuthenticationFilter;
-import nextstep.security.authentication.UsernamePasswordAuthenticationFilter;
-import nextstep.security.authentication.UsernamePasswordAuthenticationProvider;
+import nextstep.security.access.matcher.MvcRequestMatcher;
+import nextstep.security.authentication.*;
 import nextstep.security.config.DefaultSecurityFilterChain;
 import nextstep.security.config.FilterChainProxy;
 import nextstep.security.config.SecurityFilterChain;
@@ -13,6 +11,7 @@ import nextstep.security.context.SecurityContextRepository;
 import nextstep.security.userdetails.UserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.filter.DelegatingFilterProxy;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -36,7 +35,11 @@ public class AuthConfig implements WebMvcConfigurer {
 
     @Bean
     public FilterChainProxy filterChainProxy() {
-        return new FilterChainProxy(List.of(securityFilterChain()));
+        return new FilterChainProxy(List.of(
+                loginSecurityFilterChain(),
+                getMembersAuthorizationSecurityFilterChain()
+            )
+        );
     }
 
     @Bean
@@ -45,6 +48,28 @@ public class AuthConfig implements WebMvcConfigurer {
         filters.add(new UsernamePasswordAuthenticationFilter(authenticationManager(), securityContextRepository()));
         filters.add(new BasicAuthenticationFilter(authenticationManager()));
         return new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE, filters);
+    }
+
+    @Bean
+    public SecurityFilterChain loginSecurityFilterChain() {
+        MvcRequestMatcher LOGIN_REQUEST_MATCHER = new MvcRequestMatcher(HttpMethod.POST, "/login");
+
+        List<Filter> filters = new ArrayList<>();
+        filters.add(new UsernamePasswordAuthenticationFilter(authenticationManager(), securityContextRepository()));
+
+        return new DefaultSecurityFilterChain(LOGIN_REQUEST_MATCHER, filters);
+    }
+
+    @Bean
+    public SecurityFilterChain getMembersAuthorizationSecurityFilterChain() {
+        MvcRequestMatcher MEMBERS_REQUEST_MATCHER = new MvcRequestMatcher(HttpMethod.GET, "/members");
+        String ROLE_NAME = "ADMIN";
+
+        List<Filter> filters = new ArrayList<>();
+        filters.add(new BasicAuthenticationFilter(authenticationManager()));
+        filters.add(new AuthorizationFilter(ROLE_NAME));
+
+        return new DefaultSecurityFilterChain(MEMBERS_REQUEST_MATCHER, filters);
     }
 
     @Bean

--- a/src/main/java/nextstep/security/authentication/AuthorizationFilter.java
+++ b/src/main/java/nextstep/security/authentication/AuthorizationFilter.java
@@ -1,0 +1,43 @@
+package nextstep.security.authentication;
+
+import nextstep.security.context.SecurityContextHolder;
+import nextstep.security.exception.AuthorizationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class AuthorizationFilter extends GenericFilterBean {
+
+    private final String role;
+
+    public AuthorizationFilter(String role) {
+        this.role = role;
+    }
+
+    @Override
+    public void doFilter(
+            ServletRequest request,
+            ServletResponse response,
+            FilterChain chain
+    ) throws IOException, ServletException {
+        try {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+            if (!authentication.getAuthorities().contains(role)) {
+                ((HttpServletResponse) response).sendError(HttpStatus.FORBIDDEN.value(), HttpStatus.FORBIDDEN.getReasonPhrase());
+                return;
+            }
+        } catch (AuthorizationException e) {
+            ((HttpServletResponse) response).sendError(HttpStatus.UNAUTHORIZED.value(), HttpStatus.UNAUTHORIZED.getReasonPhrase());
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/nextstep/security/authentication/AuthorizationFilter.java
+++ b/src/main/java/nextstep/security/authentication/AuthorizationFilter.java
@@ -1,6 +1,8 @@
 package nextstep.security.authentication;
 
+import nextstep.security.context.SecurityContext;
 import nextstep.security.context.SecurityContextHolder;
+import nextstep.security.context.SecurityContextRepository;
 import nextstep.security.exception.AuthorizationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.filter.GenericFilterBean;
@@ -9,15 +11,19 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Set;
 
 public class AuthorizationFilter extends GenericFilterBean {
 
     private final String role;
+    private final SecurityContextRepository securityContextRepository;
 
-    public AuthorizationFilter(String role) {
+    public AuthorizationFilter(String role, SecurityContextRepository securityContextRepository) {
         this.role = role;
+        this.securityContextRepository = securityContextRepository;
     }
 
     @Override
@@ -27,9 +33,9 @@ public class AuthorizationFilter extends GenericFilterBean {
             FilterChain chain
     ) throws IOException, ServletException {
         try {
-            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            Set <String> roles = getRoles(request);
 
-            if (!authentication.getAuthorities().contains(role)) {
+            if (!roles.contains(role)) {
                 ((HttpServletResponse) response).sendError(HttpStatus.FORBIDDEN.value(), HttpStatus.FORBIDDEN.getReasonPhrase());
                 return;
             }
@@ -39,5 +45,15 @@ public class AuthorizationFilter extends GenericFilterBean {
         }
 
         chain.doFilter(request, response);
+    }
+
+    private Set<String> getRoles(ServletRequest request) {
+        SecurityContext context = securityContextRepository.loadContext((HttpServletRequest) request);
+        if (context != null) {
+            return context.getAuthentication().getAuthorities();
+        } else {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            return authentication.getAuthorities();
+        }
     }
 }

--- a/src/main/java/nextstep/security/authentication/UsernamePasswordAuthentication.java
+++ b/src/main/java/nextstep/security/authentication/UsernamePasswordAuthentication.java
@@ -31,8 +31,8 @@ public class UsernamePasswordAuthentication implements Authentication {
             String username,
             String password
     ) {
-        Set<String> defaultAuthorites = Set.of();
-        return new UsernamePasswordAuthentication(username, password, defaultAuthorites);
+        Set<String> defaultAuthorities = Set.of();
+        return new UsernamePasswordAuthentication(username, password, defaultAuthorities);
     }
 
     @Override

--- a/src/main/java/nextstep/security/authentication/UsernamePasswordAuthentication.java
+++ b/src/main/java/nextstep/security/authentication/UsernamePasswordAuthentication.java
@@ -1,26 +1,38 @@
 package nextstep.security.authentication;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public class UsernamePasswordAuthentication implements Authentication {
     private final String username;
     private final String password;
     private boolean authenticated = false;
+    private final Set<String> authorities;
 
-    private UsernamePasswordAuthentication(String username, String password) {
+    private UsernamePasswordAuthentication(String username, String password, Set<String> authorities) {
         this.username = username;
         this.password = password;
+        this.authorities = authorities;
     }
 
-    public static UsernamePasswordAuthentication ofAuthenticated(String username, String password) {
-        UsernamePasswordAuthentication authentication = new UsernamePasswordAuthentication(username, password);
+    public static UsernamePasswordAuthentication ofAuthenticated(
+            String username,
+            String password,
+            Set<String> authorities
+    ) {
+        UsernamePasswordAuthentication authentication
+                = new UsernamePasswordAuthentication(username, password, authorities);
         authentication.authenticated = true;
         return authentication;
     }
 
-    public static UsernamePasswordAuthentication ofRequest(String username, String password) {
-        return new UsernamePasswordAuthentication(username, password);
+    public static UsernamePasswordAuthentication ofRequest(
+            String username,
+            String password
+    ) {
+        Set<String> defaultAuthorites = Set.of();
+        return new UsernamePasswordAuthentication(username, password, defaultAuthorites);
     }
 
     @Override
@@ -35,7 +47,7 @@ public class UsernamePasswordAuthentication implements Authentication {
 
     @Override
     public Set<String> getAuthorities() {
-        return Collections.emptySet();
+        return authorities;
     }
 
     @Override

--- a/src/main/java/nextstep/security/authentication/UsernamePasswordAuthenticationProvider.java
+++ b/src/main/java/nextstep/security/authentication/UsernamePasswordAuthenticationProvider.java
@@ -23,7 +23,7 @@ public class UsernamePasswordAuthenticationProvider implements AuthenticationPro
             throw new AuthenticationException();
         }
 
-        return UsernamePasswordAuthentication.ofAuthenticated(username, password);
+        return UsernamePasswordAuthentication.ofAuthenticated(username, password, userDetails.getAuthorities());
     }
 
     @Override

--- a/src/main/java/nextstep/security/exception/AuthorizationException.java
+++ b/src/main/java/nextstep/security/exception/AuthorizationException.java
@@ -1,0 +1,4 @@
+package nextstep.security.exception;
+
+public class AuthorizationException extends RuntimeException {
+}

--- a/src/main/java/nextstep/security/userdetails/BaseUser.java
+++ b/src/main/java/nextstep/security/userdetails/BaseUser.java
@@ -1,13 +1,17 @@
 package nextstep.security.userdetails;
 
+import java.util.Set;
+
 public class BaseUser implements UserDetails {
 
     private final String username;
     private final String password;
+    private final Set<String> authorities;
 
-    public BaseUser(String username, String password) {
+    public BaseUser(String username, String password, Set<String> authorities) {
         this.username = username;
         this.password = password;
+        this.authorities = authorities;
     }
 
     @Override
@@ -20,4 +24,6 @@ public class BaseUser implements UserDetails {
         return password;
     }
 
+    @Override
+    public Set<String> getAuthorities() { return authorities; }
 }

--- a/src/main/java/nextstep/security/userdetails/UserDetails.java
+++ b/src/main/java/nextstep/security/userdetails/UserDetails.java
@@ -1,9 +1,12 @@
 package nextstep.security.userdetails;
 
 import java.io.Serializable;
+import java.util.Set;
 
 public interface UserDetails extends Serializable {
     String getUsername();
 
     String getPassword();
+
+    Set<String> getAuthorities();
 }

--- a/src/test/java/nextstep/app/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/app/MemberAcceptanceTest.java
@@ -30,7 +30,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .when()
                 .post("/login")
                 .then().log().all()
-                .extract();;
+                .extract();
 
         ExtractableResponse<Response> memberResponse = RestAssured.given().log().all()
                 .cookies(loginResponse.cookies())

--- a/src/test/java/nextstep/security/fixture/TestUserInmemoryRepository.java
+++ b/src/test/java/nextstep/security/fixture/TestUserInmemoryRepository.java
@@ -2,15 +2,12 @@ package nextstep.security.fixture;
 
 import nextstep.security.userdetails.BaseUser;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class TestUserInmemoryRepository {
-    public static final BaseUser TEST_MEMBER_1 = new BaseUser("a@a.com", "password");
-    public static final BaseUser TEST_MEMBER_2 = new BaseUser("b@b.com", "password");
+    public static final BaseUser TEST_MEMBER_1 = new BaseUser("a@a.com", "password", Set.of("ADMIN"));
+    public static final BaseUser TEST_MEMBER_2 = new BaseUser("b@b.com", "password", Set.of("ADMIN"));
     private static final Map<String, BaseUser> users = new HashMap<>();
 
     static {


### PR DESCRIPTION
부용님 안녕하세요! 
공부에는 핑계가 많으면 안된다고 했는데...... 독감의 늪에 빠져있느라 이번 주차도 1단계 PR요청이 다소 늦어졌습니다..🥺 (감기조심하셔요 꼭꼭!!)

### 작업사항
- 권한(authorities) 관련 필드, 메소드 추가
- ADMIN 권한을 가진 사용자만 Member 목록 조회가 가능하도록 하는 AuthorizationFilter 추가
- 기존의 securityFilterChain을 필요한 역할에 맞게 분리
  - login
  - GET /members 호출 시 권한 확인

### 질문입니다!!
제가 `SecurityContextRepository`와 `SecurityContextHolder` 를 잘 이해하지 못하고 작업을 하고 있는건지, 
MemberAcceptanceTest > .get("/members") 로직 실행 중 AuthorizationFilter릍 통과할 때 
SecurityContextHolder 에서 /login시 저장되었다고 생각한 context 값을 못읽어와서 NPE가 발생하더라구요.
<img width="500" alt="Screen Shot 2022-12-11 at 7 15 21 PM" src="https://user-images.githubusercontent.com/10671079/206898020-2b9091a3-6652-42eb-b53a-1f69bf085930.png">

일단 테스트는 통과시켜야지 싶어 이 커밋(cac6cad475abf2325451111daf3bd0e840fa7160) 에서 securityContextRepository를 직접 주입받아 값을 가져오는 방식으로 해결을 해보려 했는데 보기에 모양새가 많이 이상합니다. ㅠㅠ 
제가 어떤 부분을 놓쳤는지 힌트를 주실 수 있으시면 수정해보도록 하겠습니다!! 🙏 